### PR TITLE
Use stable version of the multipart stream builder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": "^5.5 || ^7.0",
         "mekras/class-helpers": "^1.4",
         "php-http/client-implementation": "^1.0",
-        "php-http/multipart-stream-builder": "^0.1",
+        "php-http/multipart-stream-builder": "^1.0",
         "psr/log": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | maybe
| Deprecations?   | no
| Related tickets | n/a
| License         | MIT


#### What's in this PR?

There is one thing that might be considered as a BC break. If we, for whatever reason, added multiple streams/post data with the same name. Before they were overridden but since 0.2.0 we do allow duplicate values. 

